### PR TITLE
Modified .ctor of membaseclient to use proper overload

### DIFF
--- a/Membase/MembaseClient.cs
+++ b/Membase/MembaseClient.cs
@@ -21,7 +21,7 @@ namespace Membase
 		/// Initializes a new instance of the <see cref="T:Membase.MembaseClient" /> class using the default configuration and bucket.
 		/// </summary>
 		/// <remarks>The configuration is taken from the /configuration/membase section.</remarks>
-		public MembaseClient() : this(DefaultConfig, null, null) { }
+		public MembaseClient() : this(DefaultConfig) { }
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="T:Membase.MembaseClient" /> class using the default configuration and the specified bucket.


### PR DESCRIPTION
a -

This pull request is for a bug where when a instance of the client is created with the default .ctor and a configuration, the default bucket is being used as opposed to the configured bucket.

I didn't provide a unit test because I didn't see any direct way of determining the configuration of the client object...so no place to add an assertion :(

I did test this visually by changing the bucket name in the config and then verifying via the membase console that the correct bucket was being used.

-Jeff
