### PR TITLE
Better signing

### DIFF
--- a/build/CommonProperties.targets
+++ b/build/CommonProperties.targets
@@ -41,4 +41,10 @@
 		<AssemblyOriginatorKeyFile></AssemblyOriginatorKeyFile>
 		<DelaySign>false</DelaySign>
 	</PropertyGroup>
+
+	<!-- if private signature is supplied, use it regarless other settings -->
+	<PropertyGroup Condition="Exists('..\private.snk')">
+		<AssemblyOriginatorKeyFile>..\private.snk</AssemblyOriginatorKeyFile>
+		<DelaySign>false</DelaySign>
+	</PropertyGroup>
 </Project>


### PR DESCRIPTION
Hi,
It is not very convenient to sign assembly as it is implemented now. User has to define PrivateKeyPath variable and pass it to the Msbuild or hack CommonProperties.target xml file.

The proposed patch looks up a file with predefined name "private.snk" and if it exists, use it.
It makes compilation with your own signature as simple as putting a signature file into root folder and renaming it to "private.snk".
