### PR TITLE
Alternate constructor should leave client in usable state

### DIFF
--- a/Enyim.Caching/MemcachedClient.cs
+++ b/Enyim.Caching/MemcachedClient.cs
@@ -94,6 +94,12 @@ namespace Enyim.Caching
 
 			this.pool = pool;
 			this.StartPool();
+
+            StoreOperationResultFactory = new DefaultStoreOperationResultFactory();
+            GetOperationResultFactory = new DefaultGetOperationResultFactory();
+            MutateOperationResultFactory = new DefaultMutateOperationResultFactory();
+            ConcatOperationResultFactory = new DefaultConcatOperationResultFactory();
+            RemoveOperationResultFactory = new DefaultRemoveOperationResultFactory();
 		}
 
 		private void StartPool()


### PR DESCRIPTION
The non config based constructor was leaving the client in an unusable state. Where the OperationResultFactories were all null. This would result in NulReferenceExceptions when trying to use the client. 

Fix is to initialize those to defaults just like the configuration constructor does.
