### PR TITLE
Use NuGet to download binary dependency on NUnit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ TestResults/*
 *.user
 build/output/*
 _ReSharper*
+/packages

--- a/Enyim.Caching.Log4NetAdapter/Enyim.Caching.Log4NetAdapter.csproj
+++ b/Enyim.Caching.Log4NetAdapter/Enyim.Caching.Log4NetAdapter.csproj
@@ -41,7 +41,9 @@
     <None Include="Demo.config">
       <SubType>Designer</SubType>
     </None>
-    <None Include="Enyim.Caching.Log4NetAdapter.nuspec" />
+    <None Include="Enyim.Caching.Log4NetAdapter.nuspec">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/Enyim.Caching.NLogAdapter/Enyim.Caching.NLogAdapter.csproj
+++ b/Enyim.Caching.NLogAdapter/Enyim.Caching.NLogAdapter.csproj
@@ -50,7 +50,9 @@
     <None Include="Demo.config">
       <SubType>Designer</SubType>
     </None>
-    <None Include="Enyim.Caching.NLogAdapter.nuspec" />
+    <None Include="Enyim.Caching.NLogAdapter.nuspec">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/MemcachedTest/MemcachedTest.csproj
+++ b/MemcachedTest/MemcachedTest.csproj
@@ -11,6 +11,8 @@
     <AssemblyName>MemcachedTest</AssemblyName>
     <WarningLevel>4</WarningLevel>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <Import Project="..\build\CommonProperties.targets" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -23,8 +25,13 @@
     <Reference Include="log4net">
       <HintPath>..\binaries\log4net\log4net.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.5.7.10213, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL" />
-    <Reference Include="nunit.mocks, Version=2.5.7.10213, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL" />
+    <Reference Include="nunit.framework">
+      <HintPath>..\packages\NUnit.2.6.2\lib\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="nunit.mocks">
+      <HintPath>..\packages\NUnit.Mocks.2.6.2\lib\nunit.mocks.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />
     <Reference Include="System.Core">
@@ -58,6 +65,8 @@
     <None Include="App.config">
       <SubType>Designer</SubType>
     </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSHARP.Targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
 </Project>

--- a/MemcachedTest/packages.config
+++ b/MemcachedTest/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="2.6.2" targetFramework="net35" />
+  <package id="NUnit.Mocks" version="2.6.2" targetFramework="net35" />
+</packages>


### PR DESCRIPTION
When you download project from source and attempt to compile it, the error will happen unless you have proper version of NUnit installed in GAC.

NuGet is quite popular nowadays and allows to avoid inclusion of binary dependencies into source tree.

This patch adds NUnit and NUnitMock projects dependencies using NuGet which allows to compile the project out of sources without additional modifications.
