### PR TITLE
Dispose all performance counters when disposing OpMonitor

### DIFF
--- a/Enyim.Caching/Memcached/PerformanceMonitor/DefaultPerformanceMonitor.cs
+++ b/Enyim.Caching/Memcached/PerformanceMonitor/DefaultPerformanceMonitor.cs
@@ -224,7 +224,7 @@ namespace Enyim.Caching.Memcached
 
 			public void Dispose()
 			{
-				((IDisposable)this.pcTotalPerSec).Dispose();
+				((IDisposable)this).Dispose();
 			}
 
 			void IDisposable.Dispose()


### PR DESCRIPTION
Resolves errors caused by double pcTotalPerSec disposal which can happen when OpMonitor is disposed (via the public Dispose method, not the explicit IDisposable.Dispose one) and then finalized.
