### PR TITLE
EnyimMemcached with touch support

### DIFF
--- a/Enyim.Caching.Tests/Enyim.Caching.Tests.csproj
+++ b/Enyim.Caching.Tests/Enyim.Caching.Tests.csproj
@@ -64,6 +64,7 @@
     <Compile Include="KetamaTest.cs" />
     <Compile Include="MemcachedClientCasTests.cs" />
     <Compile Include="MemcachedClientConcatTests.cs" />
+    <Compile Include="MemcachedClientTouchTests.cs" />
     <Compile Include="MemcachedClientGetTests.cs" />
     <Compile Include="MemcachedClientMutateTests.cs" />
     <Compile Include="MemcachedClientRemoveTests.cs" />

--- a/Enyim.Caching.Tests/MemcachedClientTestsBase.cs
+++ b/Enyim.Caching.Tests/MemcachedClientTestsBase.cs
@@ -137,6 +137,18 @@ namespace Enyim.Caching.Tests
 			Assert.That(result.Cas, Is.EqualTo(0), "Cas value was not 0");
 			Assert.That(result.StatusCode, Is.Null.Or.GreaterThan(0), "StatusCode not greater than 0");
 		}
+
+		protected void TouchAssertPass(ITouchOperationResult result)
+		{
+			Assert.That(result.Success, Is.True, "Success was false");
+			Assert.That(result.StatusCode, Is.EqualTo(0), "StatusCode was not 0");
+		}
+
+		protected void TouchAssertFail(ITouchOperationResult result)
+		{
+			Assert.That(result.Success, Is.False, "Success was true");
+			Assert.That(result.StatusCode, Is.Null.Or.GreaterThan(0), "StatusCode not greater than 0");
+		}
 	}
 }
 

--- a/Enyim.Caching.Tests/MemcachedClientTouchTests.cs
+++ b/Enyim.Caching.Tests/MemcachedClientTouchTests.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using NUnit.Framework;
+
+
+namespace Enyim.Caching.Tests
+{
+	[TestFixture]
+	public class MemcachedClientTouchTests : MemcachedClientTestsBase
+	{
+		[Test]
+		public void When_Touching_Existing_Item_Result_Is_Successful()
+		{
+			var key = GetUniqueKey("get");
+			var value = GetRandomString();
+			var storeResult = Store(key: key, value: value);
+			StoreAssertPass(storeResult);
+
+			var touchResult = _Client.ExecuteTouch(key, new TimeSpan(0, 1, 0));
+			TouchAssertPass(touchResult);
+		}
+
+		[Test]
+		public void When_Touching_Nonexistent_Item_Result_Is_NotSuccessful()
+		{
+			var key = GetUniqueKey("get");
+			var touchResult = _Client.ExecuteTouch(key, new TimeSpan(0, 1, 0));
+			TouchAssertFail(touchResult);
+		}
+	}
+}
+
+#region [ License information          ]
+/* ************************************************************
+ * 
+ *    @author Couchbase <info@couchbase.com>
+ *    @copyright 2012 Couchbase, Inc.
+ *    @copyright 2012 Attila Kiskó, enyim.com
+ *    
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *    
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *    
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *    
+ * ************************************************************/
+#endregion

--- a/Enyim.Caching/Enyim.Caching.csproj
+++ b/Enyim.Caching/Enyim.Caching.csproj
@@ -213,6 +213,7 @@
     </Compile>
     <Compile Include="Memcached\Protocol\Binary\StoreOperation.cs">
     </Compile>
+    <Compile Include="Memcached\Protocol\Binary\TouchOperation.cs" />
     <Compile Include="Memcached\Protocol\ItemOperation.cs">
     </Compile>
     <Compile Include="Memcached\Protocol\MultiItemOperation.cs">
@@ -244,9 +245,11 @@
     </Compile>
     <Compile Include="Memcached\Protocol\Text\TextSocketHelper.cs">
     </Compile>
+    <Compile Include="Memcached\Protocol\Text\TouchOperation.cs" />
     <Compile Include="Memcached\Results\BinaryOperationResult.cs" />
     <Compile Include="Memcached\Results\ConcatOperationResult.cs" />
     <Compile Include="Memcached\Results\Extensions\OperationResultExtensions.cs" />
+    <Compile Include="Memcached\Results\Factories\DefaultTouchOperationResultFactory.cs" />
     <Compile Include="Memcached\Results\Factories\IGetOperationResultFactory`1.cs" />
     <Compile Include="Memcached\Results\Factories\DefaultConcatOperationResultFactory.cs" />
     <Compile Include="Memcached\Results\Factories\DefaultGetOperationResultFactory.cs" />
@@ -258,12 +261,14 @@
     <Compile Include="Memcached\Results\Factories\IGetOperationResultFactory.cs" />
     <Compile Include="Memcached\Results\Factories\IMutateOperationResultFactory.cs" />
     <Compile Include="Memcached\Results\Factories\IRemoveOperationResultFactory.cs" />
+    <Compile Include="Memcached\Results\Factories\ITouchOperationResultFactory.cs" />
     <Compile Include="Memcached\Results\GetOperationResult`1.cs" />
     <Compile Include="Memcached\Results\Helpers\ResultHelper.cs" />
     <Compile Include="Memcached\Results\IGetOperationResult`1.cs" />
     <Compile Include="Memcached\Results\IPooledSocketResult.cs" />
     <Compile Include="Memcached\Results\IRemoveOperationResult.cs" />
     <Compile Include="Memcached\Results\Factories\IStoreOperationResultFactory.cs" />
+    <Compile Include="Memcached\Results\ITouchOperationResult.cs" />
     <Compile Include="Memcached\Results\PooledSocketResult.cs" />
     <Compile Include="Memcached\Results\RemoveOperationResult.cs" />
     <Compile Include="Memcached\Results\GetOperationResult.cs" />
@@ -280,6 +285,7 @@
     <Compile Include="Memcached\Results\StatusCodes\StatusCodeMessages.cs" />
     <Compile Include="Memcached\Results\StoreOperationResult.cs" />
     <Compile Include="Memcached\Results\TextOperationResult.cs" />
+    <Compile Include="Memcached\Results\TouchOperationResult.cs" />
     <Compile Include="Memcached\ServerStats.cs">
     </Compile>
     <Compile Include="Memcached\SlidingBuffer.cs" />

--- a/Enyim.Caching/IMemcachedClient.cs
+++ b/Enyim.Caching/IMemcachedClient.cs
@@ -52,6 +52,8 @@ namespace Enyim.Caching
 
 		void FlushAll();
 
+		bool Touch(string key, TimeSpan validFor);
+
 		ServerStats Stats();
 		ServerStats Stats(string type);
 

--- a/Enyim.Caching/Memcached/IOperationFactory.cs
+++ b/Enyim.Caching/Memcached/IOperationFactory.cs
@@ -17,6 +17,8 @@ namespace Enyim.Caching.Memcached
 
 		IStatsOperation Stats(string type);
 		IFlushOperation Flush();
+
+		ITouchOperation Touch(string key, uint expires);
 	}
 }
 

--- a/Enyim.Caching/Memcached/OperationInterfaces.cs
+++ b/Enyim.Caching/Memcached/OperationInterfaces.cs
@@ -77,6 +77,10 @@ namespace Enyim.Caching.Memcached
 	{
 	}
 
+	public interface ITouchOperation : ISingleItemOperation
+	{
+	}
+
 	public struct CasResult<T>
 	{
 		public T Result { get; set; }

--- a/Enyim.Caching/Memcached/Protocol/Binary/BinaryOperationFactory.cs
+++ b/Enyim.Caching/Memcached/Protocol/Binary/BinaryOperationFactory.cs
@@ -47,7 +47,12 @@ namespace Enyim.Caching.Memcached.Protocol.Binary
 		{
 			return new FlushOperation();
 		}
-	}
+
+        ITouchOperation IOperationFactory.Touch(string key, uint expires)
+        {
+            return new TouchOperation(key, expires);
+        }
+    }
 }
 
 #region [ License information          ]

--- a/Enyim.Caching/Memcached/Protocol/Binary/TouchOperation.cs
+++ b/Enyim.Caching/Memcached/Protocol/Binary/TouchOperation.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Text;
+using Enyim.Caching.Memcached.Results;
+using Enyim.Caching.Memcached.Results.Extensions;
+using Enyim.Caching.Memcached.Results.Helpers;
+
+namespace Enyim.Caching.Memcached.Protocol.Binary
+{
+	public class TouchOperation : BinarySingleItemOperation, ITouchOperation
+	{
+		private static readonly Enyim.Caching.ILog log = Enyim.Caching.LogManager.GetLogger(typeof(TouchOperation));
+
+		private uint expires;
+
+		public TouchOperation(string key, uint expires) : base(key)
+		{
+			this.expires = expires;
+		}
+
+		protected override BinaryRequest Build()
+		{
+			var extra = new byte[4];
+			BinaryConverter.EncodeUInt32(expires, extra, 0);
+
+			var request = new BinaryRequest(OpCode.Touch)
+			{
+				Key = this.Key,
+				Extra = new ArraySegment<byte>(extra)
+			};
+
+			return request;
+		}
+
+		protected override IOperationResult ProcessResponse(BinaryResponse response)
+		{
+			var result = new BinaryOperationResult();
+#if EVEN_MORE_LOGGING
+			if (log.IsDebugEnabled)
+				if (response.StatusCode == 0)
+					log.DebugFormat("Touch succeeded for key '{0}'.", this.Key);
+				else
+					log.DebugFormat("Touch failed for key '{0}'. Reason: {1}", this.Key, Encoding.ASCII.GetString(response.Data.Array, response.Data.Offset, response.Data.Count));
+#endif
+			if (response.StatusCode == 0)
+			{
+				return result.Pass();
+			}
+			else
+			{
+				var message = ResultHelper.ProcessResponseData(response.Data);
+				return result.Fail(message);
+			}
+		}
+	}
+}
+
+#region [ License information          ]
+/* ************************************************************
+ * 
+ *    Copyright (c) 2010 Attila Kiskó, enyim.com
+ *    
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *    
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *    
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *    
+ * ************************************************************/
+#endregion

--- a/Enyim.Caching/Memcached/Protocol/Text/TextOperationFactory.cs
+++ b/Enyim.Caching/Memcached/Protocol/Text/TextOperationFactory.cs
@@ -53,6 +53,11 @@ namespace Enyim.Caching.Memcached.Protocol.Text
 		{
 			return new FlushOperation();
 		}
+
+		ITouchOperation IOperationFactory.Touch(string key, uint expires)
+		{
+			return new TouchOperation(key, expires);
+		}
 	}
 }
 

--- a/Enyim.Caching/Memcached/Protocol/Text/TouchOperation.cs
+++ b/Enyim.Caching/Memcached/Protocol/Text/TouchOperation.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using Enyim.Caching.Memcached.Results;
+
+namespace Enyim.Caching.Memcached.Protocol.Text
+{
+	public class TouchOperation : SingleItemOperation, ITouchOperation
+	{
+		private uint expires;
+
+		internal TouchOperation(string key, uint expires)
+			: base(key)
+		{
+			this.expires = expires;
+		}
+
+		protected internal override IList<ArraySegment<byte>> GetBuffer()
+		{
+			var command = "touch " + this.Key + " " + this.expires + TextSocketHelper.CommandTerminator;
+
+			return TextSocketHelper.GetCommandBuffer(command);
+		}
+
+		protected internal override IOperationResult ReadResponse(PooledSocket socket)
+		{
+			return new TextOperationResult
+			{
+				Success = String.Compare(TextSocketHelper.ReadResponse(socket), "TOUCHED", StringComparison.Ordinal) == 0
+			};
+		}
+
+		protected internal override bool ReadResponseAsync(PooledSocket socket, System.Action<bool> next)
+		{
+			throw new System.NotSupportedException();
+		}
+	}
+}
+
+#region [ License information          ]
+/* ************************************************************
+ * 
+ *    Copyright (c) 2010 Attila Kiskó, enyim.com
+ *    
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *    
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *    
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *    
+ * ************************************************************/
+#endregion

--- a/Enyim.Caching/Memcached/Results/Factories/DefaultTouchOperationResultFactory.cs
+++ b/Enyim.Caching/Memcached/Results/Factories/DefaultTouchOperationResultFactory.cs
@@ -1,50 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 
-namespace Enyim.Caching.Memcached.Protocol.Binary
+namespace Enyim.Caching.Memcached.Results.Factories
 {
-	public enum OpCode : byte
+	public class DefaultTouchOperationResultFactory : ITouchOperationResultFactory
 	{
-		Get = 0x00,
-		Set = 0x01,
-		Add = 0x02,
-		Replace = 0x03,
-		Delete = 0x04,
-		Increment = 0x05,
-		Decrement = 0x06,
-		Quit = 0x07,
-		Flush = 0x08,
-		GetQ = 0x09,
-		NoOp = 0x0A,
-		Version = 0x0B,
-		GetK = 0x0C,
-		GetKQ = 0x0D,
-		Append = 0x0E,
-		Prepend = 0x0F,
-		Stat = 0x10,
-		SetQ = 0x11,
-		AddQ = 0x12,
-		ReplaceQ = 0x13,
-		DeleteQ = 0x14,
-		IncrementQ = 0x15,
-		DecrementQ = 0x16,
-		QuitQ = 0x17,
-		FlushQ = 0x18,
-		AppendQ = 0x19,
-		PrependQ = 0x1A,
-		Touch = 0x1C,
-		GetAndTouch = 0x1D,
-		GetAndTouchQ = 0x1E,
-
-		// SASL authentication op-codes
-		SaslList = 0x20,
-		SaslStart = 0x21,
-		SaslStep = 0x22
-	};
+		public ITouchOperationResult Create()
+		{
+			return new TouchOperationResult()
+			{
+				Success = false,
+				Message = string.Empty
+			};
+		}
+	}
 }
 
 #region [ License information          ]
 /* ************************************************************
  * 
- *    Copyright (c) 2010 Attila Kisk�, enyim.com
+ *    @author Couchbase <info@couchbase.com>
+ *    @copyright 2012 Couchbase, Inc.
+ *    @copyright 2012 Attila Kiskó, enyim.com
  *    
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/Enyim.Caching/Memcached/Results/Factories/ITouchOperationResultFactory.cs
+++ b/Enyim.Caching/Memcached/Results/Factories/ITouchOperationResultFactory.cs
@@ -1,50 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 
-namespace Enyim.Caching.Memcached.Protocol.Binary
+namespace Enyim.Caching.Memcached.Results.Factories
 {
-	public enum OpCode : byte
+	public interface ITouchOperationResultFactory
 	{
-		Get = 0x00,
-		Set = 0x01,
-		Add = 0x02,
-		Replace = 0x03,
-		Delete = 0x04,
-		Increment = 0x05,
-		Decrement = 0x06,
-		Quit = 0x07,
-		Flush = 0x08,
-		GetQ = 0x09,
-		NoOp = 0x0A,
-		Version = 0x0B,
-		GetK = 0x0C,
-		GetKQ = 0x0D,
-		Append = 0x0E,
-		Prepend = 0x0F,
-		Stat = 0x10,
-		SetQ = 0x11,
-		AddQ = 0x12,
-		ReplaceQ = 0x13,
-		DeleteQ = 0x14,
-		IncrementQ = 0x15,
-		DecrementQ = 0x16,
-		QuitQ = 0x17,
-		FlushQ = 0x18,
-		AppendQ = 0x19,
-		PrependQ = 0x1A,
-		Touch = 0x1C,
-		GetAndTouch = 0x1D,
-		GetAndTouchQ = 0x1E,
-
-		// SASL authentication op-codes
-		SaslList = 0x20,
-		SaslStart = 0x21,
-		SaslStep = 0x22
-	};
+		ITouchOperationResult Create();
+	}
 }
 
 #region [ License information          ]
 /* ************************************************************
  * 
- *    Copyright (c) 2010 Attila Kisk�, enyim.com
+ *    @author Couchbase <info@couchbase.com>
+ *    @copyright 2012 Couchbase, Inc.
+ *    @copyright 2012 Attila Kiskó, enyim.com
  *    
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/Enyim.Caching/Memcached/Results/ITouchOperationResult.cs
+++ b/Enyim.Caching/Memcached/Results/ITouchOperationResult.cs
@@ -1,50 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 
-namespace Enyim.Caching.Memcached.Protocol.Binary
+namespace Enyim.Caching.Memcached.Results
 {
-	public enum OpCode : byte
-	{
-		Get = 0x00,
-		Set = 0x01,
-		Add = 0x02,
-		Replace = 0x03,
-		Delete = 0x04,
-		Increment = 0x05,
-		Decrement = 0x06,
-		Quit = 0x07,
-		Flush = 0x08,
-		GetQ = 0x09,
-		NoOp = 0x0A,
-		Version = 0x0B,
-		GetK = 0x0C,
-		GetKQ = 0x0D,
-		Append = 0x0E,
-		Prepend = 0x0F,
-		Stat = 0x10,
-		SetQ = 0x11,
-		AddQ = 0x12,
-		ReplaceQ = 0x13,
-		DeleteQ = 0x14,
-		IncrementQ = 0x15,
-		DecrementQ = 0x16,
-		QuitQ = 0x17,
-		FlushQ = 0x18,
-		AppendQ = 0x19,
-		PrependQ = 0x1A,
-		Touch = 0x1C,
-		GetAndTouch = 0x1D,
-		GetAndTouchQ = 0x1E,
-
-		// SASL authentication op-codes
-		SaslList = 0x20,
-		SaslStart = 0x21,
-		SaslStep = 0x22
-	};
+	public interface ITouchOperationResult : IOperationResult
+    {
+	}
 }
 
 #region [ License information          ]
 /* ************************************************************
  * 
- *    Copyright (c) 2010 Attila Kisk�, enyim.com
+ *    @author Couchbase <info@couchbase.com>
+ *    @copyright 2012 Couchbase, Inc.
+ *    @copyright 2012 Attila Kiskó, enyim.com
  *    
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/Enyim.Caching/Memcached/Results/TouchOperationResult.cs
+++ b/Enyim.Caching/Memcached/Results/TouchOperationResult.cs
@@ -1,50 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 
-namespace Enyim.Caching.Memcached.Protocol.Binary
+namespace Enyim.Caching.Memcached.Results
 {
-	public enum OpCode : byte
+	public class TouchOperationResult : OperationResultBase, ITouchOperationResult
 	{
-		Get = 0x00,
-		Set = 0x01,
-		Add = 0x02,
-		Replace = 0x03,
-		Delete = 0x04,
-		Increment = 0x05,
-		Decrement = 0x06,
-		Quit = 0x07,
-		Flush = 0x08,
-		GetQ = 0x09,
-		NoOp = 0x0A,
-		Version = 0x0B,
-		GetK = 0x0C,
-		GetKQ = 0x0D,
-		Append = 0x0E,
-		Prepend = 0x0F,
-		Stat = 0x10,
-		SetQ = 0x11,
-		AddQ = 0x12,
-		ReplaceQ = 0x13,
-		DeleteQ = 0x14,
-		IncrementQ = 0x15,
-		DecrementQ = 0x16,
-		QuitQ = 0x17,
-		FlushQ = 0x18,
-		AppendQ = 0x19,
-		PrependQ = 0x1A,
-		Touch = 0x1C,
-		GetAndTouch = 0x1D,
-		GetAndTouchQ = 0x1E,
 
-		// SASL authentication op-codes
-		SaslList = 0x20,
-		SaslStart = 0x21,
-		SaslStep = 0x22
-	};
+	}
 }
 
 #region [ License information          ]
 /* ************************************************************
  * 
- *    Copyright (c) 2010 Attila Kisk�, enyim.com
+ *    @author Couchbase <info@couchbase.com>
+ *    @copyright 2012 Couchbase, Inc.
+ *    @copyright 2012 Attila Kiskó, enyim.com
  *    
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/Enyim.Caching/MemcachedClient.Results.cs
+++ b/Enyim.Caching/MemcachedClient.Results.cs
@@ -470,6 +470,13 @@ namespace Enyim.Caching
 		}
 
 		#endregion
+
+		#region [ Touch			]
+		public ITouchOperationResult ExecuteTouch(string key, TimeSpan validFor)
+		{
+			return this.PerformTouch(key, MemcachedClient.GetExpiration(validFor));
+		}
+		#endregion [ Touch			]
 	}
 }
 

--- a/Enyim.Caching/MemcachedClient.cs
+++ b/Enyim.Caching/MemcachedClient.cs
@@ -35,6 +35,7 @@ namespace Enyim.Caching
 		public IMutateOperationResultFactory MutateOperationResultFactory { get; set; }
 		public IConcatOperationResultFactory ConcatOperationResultFactory { get; set; }
 		public IRemoveOperationResultFactory RemoveOperationResultFactory { get; set; }
+		public ITouchOperationResultFactory TouchOperationResultFactory { get; set; }
 
 		/// <summary>
 		/// Initializes a new MemcachedClient instance using the default configuration section (enyim/memcached).
@@ -79,6 +80,7 @@ namespace Enyim.Caching
 			MutateOperationResultFactory = new DefaultMutateOperationResultFactory();
 			ConcatOperationResultFactory = new DefaultConcatOperationResultFactory();
 			RemoveOperationResultFactory = new DefaultRemoveOperationResultFactory();
+			TouchOperationResultFactory = new DefaultTouchOperationResultFactory();
 		}
 
 		public MemcachedClient(IServerPool pool, IMemcachedKeyTransformer keyTransformer, ITranscoder transcoder)
@@ -713,6 +715,50 @@ namespace Enyim.Caching
 
 			if (this.performanceMonitor != null) this.performanceMonitor.Concatenate(mode, 1, false);
 
+			result.Fail("Unable to locate node");
+			return result;
+		}
+
+		#endregion
+		#region [ Touch                ]
+
+		public bool Touch(string key, TimeSpan validFor)
+		{
+			return this.PerformTouch(key, (uint)validFor.TotalSeconds).Success;
+		}
+
+		protected virtual ITouchOperationResult PerformTouch(string key, uint expires)
+		{
+			var hashedKey = this.keyTransformer.Transform(key);
+			var node = this.pool.Locate(hashedKey);
+			var result = TouchOperationResultFactory.Create();
+
+			if (node != null)
+			{
+				var command = this.pool.OperationFactory.Touch(hashedKey, expires);
+				var commandResult = node.Execute(command);
+
+				result.StatusCode = command.StatusCode;
+
+				if (commandResult.Success)
+				{
+					//if (this.performanceMonitor != null) this.performanceMonitor.s.Mutate(mode, 1, commandResult.Success);
+					//result.Value = command.Result;
+					result.Pass();
+					return result;
+				}
+				else
+				{
+					//if (this.performanceMonitor != null) this.performanceMonitor.Mutate(mode, 1, false);
+					result.InnerResult = commandResult;
+					result.Fail("Mutate operation failed, see InnerResult or StatusCode for more details");
+				}
+
+			}
+
+			//if (this.performanceMonitor != null) this.performanceMonitor.Mutate(mode, 1, false);
+
+			// TODO not sure about the return value when the command fails
 			result.Fail("Unable to locate node");
 			return result;
 		}

--- a/README.mdown
+++ b/README.mdown
@@ -10,6 +10,7 @@ Features:
 * CheckAndSet operations
 * Persistent connections for more speed
 * SASL Authentication
+* Touch operations (After 1.4.8 version of memcached server, for extending items' TTLs)
 
 ## Requirements
 


### PR DESCRIPTION
Touch support required for extending items' TTL value

This is a cleaned up version of PR #147.

I've tidied up the white space differences, removed the packages, and added unit tests for the added touch operation. 

Hopefully this change can be merged now :)
