### PR TITLE
fix xbuild(mono) build error

### DIFF
--- a/build/ProjectDefaults.targets
+++ b/build/ProjectDefaults.targets
@@ -20,23 +20,6 @@
 		<DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
 	</PropertyGroup>
 
-	<PropertyGroup>
-		<FrameworkVersions>NETFX_$(TargetFrameworkVersion.SubString(1).Replace(".", ""))</FrameworkVersions>
-
-		<_FWK_V>$([System.Version]::Parse($(TargetFrameworkVersion.SubString(1))))</_FWK_V>
-		<FrameworkVersions Condition=" $(_FWK_V) > 2.0 "  >$(FrameworkVersions);NETFX_20_UP</FrameworkVersions>
-		<FrameworkVersions Condition=" $(_FWK_V) > 3.0 "  >$(FrameworkVersions);NETFX_30_UP</FrameworkVersions>
-		<FrameworkVersions Condition=" $(_FWK_V) > 3.5 "  >$(FrameworkVersions);NETFX_35_UP</FrameworkVersions>
-		<FrameworkVersions Condition=" $(_FWK_V) > 4.0 "  >$(FrameworkVersions);NETFX_40_UP</FrameworkVersions>
-		<FrameworkVersions Condition=" $(_FWK_V) > 4.5 "  >$(FrameworkVersions);NETFX_45_UP</FrameworkVersions>
-		<FrameworkVersions Condition=" $(_FWK_V) > 4.5.1 ">$(FrameworkVersions);NETFX_451_UP</FrameworkVersions>
-		<FrameworkVersions Condition=" $(_FWK_V) > 4.5.2 ">$(FrameworkVersions);NETFX_452_UP</FrameworkVersions>
-		<FrameworkVersions Condition=" $(_FWK_V) > 4.6 "  >$(FrameworkVersions);NETFX_46_UP</FrameworkVersions>
-	</PropertyGroup>
-
-	<PropertyGroup >
-		<DefineConstants>$(DefineConstants);$(FrameworkVersions)</DefineConstants>
-	</PropertyGroup>
 
 	<!--
 		The Core project is merged into Memcached, so exclude from all others.


### PR DESCRIPTION
when build by xbuild, it complains error “Input string was not in a
correct format.”