### PR TITLE
Don't cast cas to uint.

### DIFF
--- a/Enyim.Caching/Memcached/Protocol/Text/TextOperationFactory.cs
+++ b/Enyim.Caching/Memcached/Protocol/Text/TextOperationFactory.cs
@@ -20,7 +20,7 @@ namespace Enyim.Caching.Memcached.Protocol.Text
 			if (cas == 0)
 				return new StoreOperation(mode, key, value, expires);
 
-			return new CasOperation(key, value, expires, (uint)cas);
+			return new CasOperation(key, value, expires, cas);
 		}
 
 		IDeleteOperation IOperationFactory.Delete(string key, ulong cas)


### PR DESCRIPTION
Fixes issue described in https://github.com/enyim/EnyimMemcached/issues/162.

Cas values are 64 bits (https://github.com/memcached/memcached/blob/master/doc/protocol.txt#L175) and should never be treated as uints.