### PR TITLE
Issue #165 - NullReferenceException when using alternative constructors

### DIFF
--- a/Enyim.Caching/MemcachedClient.cs
+++ b/Enyim.Caching/MemcachedClient.cs
@@ -97,6 +97,12 @@ namespace Enyim.Caching
 
 			this.pool = pool;
 			this.StartPool();
+
+			StoreOperationResultFactory = new DefaultStoreOperationResultFactory();
+			GetOperationResultFactory = new DefaultGetOperationResultFactory();
+			MutateOperationResultFactory = new DefaultMutateOperationResultFactory();
+			ConcatOperationResultFactory = new DefaultConcatOperationResultFactory();
+			RemoveOperationResultFactory = new DefaultRemoveOperationResultFactory();
 		}
 
 		private void StartPool()


### PR DESCRIPTION
The OperationResultFactories are not instantiated when using the constructors that do not take the IMemcachedClientConfiguration argument.

The factories are now instantiated properly in all constructors.