### PR TITLE
Fix if it is set to absolute time, unable to store the problem.

### DIFF
--- a/Enyim.Caching/MemcachedClient.cs
+++ b/Enyim.Caching/MemcachedClient.cs
@@ -958,7 +958,7 @@ namespace Enyim.Caching
 			// accept MaxValue as infinite
 			if (expiresAt == DateTime.MaxValue) return 0;
 
-			uint retval = (uint)(expiresAt.ToUniversalTime() - UnixEpoch).TotalSeconds;
+			uint retval = (uint)(expiresAt.ToUniversalTime() - DateTime.Now.ToUniversalTime()).TotalSeconds;
 
 			return retval;
 		}
@@ -1005,7 +1005,7 @@ namespace Enyim.Caching
 #region [ License information          ]
 /* ************************************************************
  * 
- *    Copyright (c) 2010 Attila Kiskó, enyim.com
+ *    Copyright (c) 2010 Attila KiskÃ³, enyim.com
  *    
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fix if it is set to absolute time, unable to store the problem.
GetExpiration(DateTime expiresAt) and
GetExpiration(TimeSpan validFor)
The meaning of the return is different, there is ambiguity.And GetExpiration (DateTime expiresAt) cannot be successfully stored