### PR TITLE
NullReferenceException in SimpleNodeLocator without nodes

### DIFF
--- a/Enyim.Caching.Tests/Enyim.Caching.Tests.csproj
+++ b/Enyim.Caching.Tests/Enyim.Caching.Tests.csproj
@@ -72,6 +72,7 @@
     <Compile Include="MemcachedClientTestsBase.cs" />
     <Compile Include="MemcachedServer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SingleNodeLocatorTest.cs" />
     <Compile Include="TestSetup.cs" />
     <Compile Include="TextMemcachedClientTest.cs" />
     <Compile Include="VBucketTest.cs" />

--- a/Enyim.Caching.Tests/SingleNodeLocatorTest.cs
+++ b/Enyim.Caching.Tests/SingleNodeLocatorTest.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Enyim.Caching.Memcached;
+using NUnit.Framework;
+
+namespace Enyim.Caching.Tests
+{
+	[TestFixture]
+	public class SingleNodeLocatorTest
+	{
+		[TestCase]
+		public void TestIfCalled()
+		{
+			var locator = (IMemcachedNodeLocator)new SingleNodeLocator();
+			locator.Initialize(new List<IMemcachedNode>());
+
+			Assert.IsNull(locator.Locate("key"));
+			Assert.AreEqual(Enumerable.Empty<IMemcachedNode>(), locator.GetWorkingNodes());
+		}
+	}
+}

--- a/Enyim.Caching.Tests/SingleNodeLocatorTest.cs
+++ b/Enyim.Caching.Tests/SingleNodeLocatorTest.cs
@@ -10,7 +10,7 @@ namespace Enyim.Caching.Tests
 	public class SingleNodeLocatorTest
 	{
 		[TestCase]
-		public void TestIfCalled()
+		public void TestInitializationWithEmptyList()
 		{
 			var locator = (IMemcachedNodeLocator)new SingleNodeLocator();
 			locator.Initialize(new List<IMemcachedNode>());

--- a/Enyim.Caching/Memcached/Locators/SingleNodeLocator.cs
+++ b/Enyim.Caching/Memcached/Locators/SingleNodeLocator.cs
@@ -36,14 +36,14 @@ namespace Enyim.Caching.Memcached
 			if (!this.isInitialized)
 				throw new InvalidOperationException("You must call Initialize first");
 
-			return this.node.IsAlive
+			return this.node != null && this.node.IsAlive
 					? this.node
 					: null;
 		}
 
 		IEnumerable<IMemcachedNode> IMemcachedNodeLocator.GetWorkingNodes()
 		{
-			return this.node.IsAlive
+			return this.node != null && this.node.IsAlive
 					? new IMemcachedNode[] { this.node }
 					: Enumerable.Empty<IMemcachedNode>();
 		}


### PR DESCRIPTION
When `SimpleNodeLocator` is inicialized with an empty list, e.g. when a node is not alive, the initialization is finished correctly but each call to `Locate` or `GetWorkingNodes` method throw `NullReferenceException` because `node` is `null` and on this object is called property `IsAlive`.

This PR added check to `null` value before using `IsAlive` property