### PR TITLE
Related to http://www.couchbase.com/issues/browse/NCBC-60 commit 278d842

### DIFF
--- a/Enyim.Caching/MemcachedClient.Results.cs
+++ b/Enyim.Caching/MemcachedClient.Results.cs
@@ -458,7 +458,7 @@ namespace Enyim.Caching
 				}
 				else
 				{
-					result.InnerResult = commandResult;
+					commandResult.Combine(result);
 					result.Fail("Failed to remove item, see InnerResult or StatusCode for details");
 				}
 


### PR DESCRIPTION
ExecuteRemove calls .Combine() to reduce depth of result objects in case of an attempt to remove a non-exiting key.